### PR TITLE
Some minor change in maxent

### DIFF
--- a/src/maxent.jl
+++ b/src/maxent.jl
@@ -1368,7 +1368,8 @@ function calc_bayes(
     end
     Λ = (T * T') .* mec.hess
 
-    λ = eigvals(Hermitian(Λ))
+    nsvd = size(mec.Vₛ, 2)
+    λ = eigvals(Hermitian(Λ))[end - nsvd + 1 : end]
     filter!(x -> x > 0.0, λ)
     ng = -2.0 * α * S
     tr = sum(λ ./ (α .+ λ))
@@ -1430,7 +1431,8 @@ function calc_bayes_od(
     end
     Λ = (T * T') .* mec.hess
 
-    λ = eigvals(Hermitian(Λ))
+    nsvd = size(mec.Vₛ, 2)
+    λ = eigvals(Hermitian(Λ))[end - nsvd + 1 : end]
     filter!(x -> x > 0.0, λ)
     ng = -2.0 * α * S
     tr = sum(λ ./ (α .+ λ))

--- a/src/maxent.jl
+++ b/src/maxent.jl
@@ -703,6 +703,7 @@ function precompute(
 
     # Compute the Hessian matrix
     @einsum hess[i,j] = Δ[i] * Δ[j] * K[k,i] * K[k,j] * σ²[k]
+    hess = (hess + hess') / 2.0
 
     return V, W₂, W₃, Bₘ, hess
 end
@@ -1368,6 +1369,7 @@ function calc_bayes(
     Λ = (T * T') .* mec.hess
 
     λ = eigvals(Hermitian(Λ))
+    filter!(x -> x > 0.0, λ)
     ng = -2.0 * α * S
     tr = sum(λ ./ (α .+ λ))
     conv = tr / ng
@@ -1429,6 +1431,7 @@ function calc_bayes_od(
     Λ = (T * T') .* mec.hess
 
     λ = eigvals(Hermitian(Λ))
+    filter!(x -> x > 0.0, λ)
     ng = -2.0 * α * S
     tr = sum(λ ./ (α .+ λ))
     conv = tr / ng


### PR DESCRIPTION
1. In some cases, `norm(hess - hess')>1e-9` so I add
```julia
hess = (hess + hess')/2
```
to guarantee it's hermitian.

2. $$TT' \circ H = \text{diag}(T)H\text{diag}(T)$$
$$\Longrightarrow \text{rank}(\Lambda) = \text{nsvd}$$

thus we only need the last `nsvd` values and filter to avoid they are so small that are calculated as zeros or negative numbers.